### PR TITLE
Prevent source file overwrite when dest resolves to same path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.9 (2026-03-10)
+- Fixed a bug where uncompressing a file with no recognized compression extension into the same directory would silently overwrite the source file (#22)
+- The module now fails with a clear error message when `src` and `dest` resolve to the same file path
+
 ## 0.0.8 (2026-01-07)
 - Added support for `dest` parameter to accept a directory path, automatically deriving the uncompressed filename from the source file (similar to `ansible.builtin.copy`)
 - Strips compression extensions (.gz, .bz2, .xz, .lzma) and replaces .txz/.tlz with .tar

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: compscidr
 name: uncompress
-version: 0.0.8
+version: 0.0.9
 readme: README.md
 authors:
   - Jason Ernst <ernstjason1@gmail.com>

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -118,3 +118,28 @@
         mode: '755'
       register: result_url_query
       # GitHub ignores query parameters, so this should work and result in /tmp/uncompress-test-dir/cheat-linux-amd64
+
+    - name: Create a compressed file with no compression extension (for overwrite test)
+      ansible.builtin.shell: |
+        echo "test content for overwrite check" > /tmp/overwrite-test.txt
+        gzip -f /tmp/overwrite-test.txt
+        mv /tmp/overwrite-test.txt.gz /tmp/overwrite-test
+      args:
+        creates: /tmp/overwrite-test
+
+    - name: Test that uncompressing a file with no extension into same directory fails
+      compscidr.uncompress.uncompress:
+        copy: false
+        src: /tmp/overwrite-test
+        dest: /tmp/
+        mode: '644'
+      register: result_overwrite
+      ignore_errors: true
+
+    - name: Verify overwrite protection triggered
+      ansible.builtin.assert:
+        that:
+          - result_overwrite is failed
+          - "'resolve to the same file' in result_overwrite.msg"
+        fail_msg: "Overwrite protection did not trigger when src and dest resolve to the same file"
+        success_msg: "Overwrite protection correctly prevented source file from being overwritten"

--- a/plugins/modules/uncompress.py
+++ b/plugins/modules/uncompress.py
@@ -279,6 +279,12 @@ def main():
         derived_filename = derive_uncompressed_filename(src)
         dest = os.path.join(dest, derived_filename)
 
+    # Check if dest would overwrite src (e.g. when src has no compression extension and dest is the same directory)
+    if os.path.realpath(src) == os.path.realpath(dest):
+        module.fail_json(msg="Source '%s' and destination '%s' resolve to the same file. "
+                         "This would overwrite the compressed source file. "
+                         "Use an explicit dest filename or rename the source to include a compression extension." % (src, dest))
+
     fdir, ffile = os.path.split(dest)
 
     # did tar file arrive?

--- a/plugins/modules/uncompress.py
+++ b/plugins/modules/uncompress.py
@@ -279,12 +279,6 @@ def main():
         derived_filename = derive_uncompressed_filename(src)
         dest = os.path.join(dest, derived_filename)
 
-    # Check if dest would overwrite src (e.g. when src has no compression extension and dest is the same directory)
-    if os.path.realpath(src) == os.path.realpath(dest):
-        module.fail_json(msg="Source '%s' and destination '%s' resolve to the same file. "
-                         "This would overwrite the compressed source file. "
-                         "Use an explicit dest filename or rename the source to include a compression extension." % (src, dest))
-
     fdir, ffile = os.path.split(dest)
 
     # did tar file arrive?
@@ -325,6 +319,13 @@ def main():
 
     if not os.access(src, os.R_OK):
         module.fail_json(msg="Source '%s' not readable" % src)
+
+    # Check if dest would overwrite src (e.g. when src has no compression extension and dest is the same directory)
+    # This check must run after src is finalized (after any URL download rewrites src to a local temp file)
+    if os.path.realpath(src) == os.path.realpath(dest):
+        module.fail_json(msg="Source '%s' and destination '%s' resolve to the same file. "
+                         "This would overwrite the compressed source file. "
+                         "Use an explicit dest filename or rename the source to include a compression extension." % (src, dest))
 
     # Full path to the uncompressed file in the temp directory.
     tempsrc = os.path.join(tempdir, ffile)


### PR DESCRIPTION
## Summary
- Fixes #22: When `src` has no compression extension (e.g. `foo` instead of `foo.gz`) and `dest` is the same directory, `derive_uncompressed_filename()` returns the filename unchanged, causing `dest` to resolve to the same path as `src` — silently overwriting the compressed source file
- Adds a `realpath` check after dest resolution that fails with a clear error message when `src` and `dest` would be the same file
- Adds a molecule test to verify the overwrite protection works

## Test plan
- [ ] Existing molecule tests still pass (directory dest, URL dest, etc.)
- [ ] New molecule test verifies that uncompressing a file with no extension into the same directory produces a clear error instead of data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)